### PR TITLE
GPIO mode: filter out improbably short pulses

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -407,6 +407,12 @@ serGetDevStatusLines ( serDevT* dev, time_f timef )
 int
 serStoreDevStatusLines ( serDevT* dev, int lines, time_f timef )
 {
+
+	time_f diff = timef - dev->eventtime;
+	if (diff < 0.05) {
+		loggerf ( LOGGER_DEBUG, "serStoreDevStatusLines: pulse too short %f, filtering!\n", diff);
+		return 0;
+	}
 	if ( lines != dev->curlines )
 	{
 		dev->prevlines = dev->curlines;


### PR DESCRIPTION
My OlinuXino-A20-Lime2 in combination with my Pollin DCF1 module
seems to be producing intermittent state transitions on the GPIO
pins which throw off radioclkd2. This is not an issue with dcf77pi which
ignores these ghost transitions, perhaps because it's sampling the
device node instead of using edge-triggered interrupts.

The shortest recognized pulse in clock.c is 0.1s, so filtering out
transitions occurring less than 0.05s after the last transition should
be safe.