### PR TITLE
allow SHM unit 0..8

### DIFF
--- a/main.c
+++ b/main.c
@@ -272,13 +272,8 @@ main ( int argc, char** argv )
                                         parm = argv[0];
                                 }
 
-                                if ( strcasecmp ( parm, "0" ) == 0 )
-                                        shmunit = 0;
-                                else if ( strcasecmp ( parm, "1" ) == 0 )
-                                        shmunit = 1;
-                                else if ( strcasecmp ( parm, "2" ) == 0 )
-                                        shmunit = 2;
-                                else
+                                shmunit = atoi(argv[0]);
+				if ( shmunit < 0 || shmunit > 8 )
                                         usage();
                                 break;
 


### PR DESCRIPTION
Extended the number of supported SHM clock references.

NTP.org: _SYSV IPC creates a shared memory segment with a key value of 0x4E545030 + u, where u is again the clock unit.
This value could be hex-decoded as NTP0, NTP1,…, with funny characters for units > 9._
